### PR TITLE
Add Terraform EC2 module for default VPC in us-east-1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,14 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.*
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json

--- a/terraform/ec2-default-vpc/.terraform.lock.hcl
+++ b/terraform/ec2-default-vpc/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/ec2-default-vpc/main.tf
+++ b/terraform/ec2-default-vpc/main.tf
@@ -1,0 +1,81 @@
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}
+
+data "aws_ami" "amazon_linux_2023" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+}
+
+resource "aws_security_group" "instance" {
+  name_prefix = "${var.name_prefix}-"
+  description = "Security group for Terraform-managed EC2 in default VPC"
+  vpc_id      = data.aws_vpc.default.id
+
+  dynamic "ingress" {
+    for_each = length(var.allowed_ssh_cidr_blocks) > 0 ? [1] : []
+    content {
+      description = "SSH"
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_blocks = var.allowed_ssh_cidr_blocks
+    }
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_instance" "this" {
+  ami                    = data.aws_ami.amazon_linux_2023.id
+  instance_type          = var.instance_type
+  subnet_id              = sort(tolist(data.aws_subnets.default.ids))[0]
+  vpc_security_group_ids = [aws_security_group.instance.id]
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
+
+  root_block_device {
+    volume_type           = "gp3"
+    volume_size           = 30
+    delete_on_termination = true
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-instance"
+  }
+}

--- a/terraform/ec2-default-vpc/outputs.tf
+++ b/terraform/ec2-default-vpc/outputs.tf
@@ -1,0 +1,24 @@
+output "instance_id" {
+  description = "ID of the EC2 instance."
+  value       = aws_instance.this.id
+}
+
+output "instance_private_ip" {
+  description = "Private IP address assigned to the instance."
+  value       = aws_instance.this.private_ip
+}
+
+output "instance_public_ip" {
+  description = "Public IP address assigned to the instance, if any."
+  value       = aws_instance.this.public_ip
+}
+
+output "vpc_id" {
+  description = "ID of the default VPC used for the instance."
+  value       = data.aws_vpc.default.id
+}
+
+output "subnet_id" {
+  description = "Subnet ID where the instance was placed."
+  value       = aws_instance.this.subnet_id
+}

--- a/terraform/ec2-default-vpc/provider.tf
+++ b/terraform/ec2-default-vpc/provider.tf
@@ -1,0 +1,9 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project = var.name_prefix
+    }
+  }
+}

--- a/terraform/ec2-default-vpc/variables.tf
+++ b/terraform/ec2-default-vpc/variables.tf
@@ -1,0 +1,23 @@
+variable "aws_region" {
+  description = "AWS region where the instance is created."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "name_prefix" {
+  description = "Prefix used for resource names and default tags."
+  type        = string
+  default     = "terraform-ec2"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type."
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "allowed_ssh_cidr_blocks" {
+  description = "CIDR blocks allowed to reach TCP 22 on the instance. Leave empty to disable SSH ingress."
+  type        = list(string)
+  default     = []
+}

--- a/terraform/ec2-default-vpc/versions.tf
+++ b/terraform/ec2-default-vpc/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change adds a small Terraform root module under `terraform/ec2-default-vpc` that provisions a single EC2 instance in the **default VPC** in **AWS region `us-east-1`**.

## What it does

- Resolves the default VPC and its subnets, then places the instance in the first subnet (lexicographically sorted for a stable choice).
- Uses the latest **Amazon Linux 2023** x86_64 AMI from the official Amazon owner ID.
- Creates a dedicated security group with full egress; **SSH (port 22) is only added** if `allowed_ssh_cidr_blocks` is non-empty (defaults to no SSH ingress for a safer baseline).
- Sets **IMDSv2 required**, **gp3** root volume (30 GiB), instance type **t3.micro** by default (overridable).

## How to use

1. Configure AWS credentials (for example `AWS_PROFILE` or environment variables).
2. From `terraform/ec2-default-vpc` run `terraform init`, then `terraform plan` and `terraform apply`.
3. Optionally set `allowed_ssh_cidr_blocks` (for example `["203.0.113.10/32"]`) in a `terraform.tfvars` file or on the command line.

## Other

- Root `.gitignore` is updated to ignore Terraform state and the `.terraform` plugin directory; **`.terraform.lock.hcl` is committed** for reproducible provider versions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c134c943-0af7-4d65-8648-1c002ea548c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c134c943-0af7-4d65-8648-1c002ea548c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

